### PR TITLE
add translate command

### DIFF
--- a/cmd/translate.go
+++ b/cmd/translate.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+// Copyright © 2018 Confbase
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-
 	"github.com/spf13/cobra"
 
 	"github.com/Confbase/schema/translate"
@@ -26,11 +25,13 @@ var translateCfg translate.Config
 // translateCmd represents the translate command
 var translateCmd = &cobra.Command{
 	Use:   "translate",
-	Short: "translate input into desired type",
-	Long: `translate input into desired type
-If no schema is specified, stdin is interpreted as the schema.
+	Short: "translate input data into another format",
+	Long: `Translate input data into another format.
 
-Multiple instance names may be specfied.
+If no input file is specified, stdin is used as input.
+
+Multiple output paths may be specfied. If none are specified, translated data
+is written to stdout.
 
 If more than one of the (json|yaml|toml|xml|protobuf|graphql) flags are set,
 behavior is undefined.`,
@@ -40,7 +41,7 @@ behavior is undefined.`,
 }
 
 func init() {
-	translateCmd.Flags().StringVarP(&translateCfg.SchemaPath, "schema", "s", "", "specifies schema to init")
+	translateCmd.Flags().StringVarP(&translateCfg.InputPath, "input", "i", "", "path to input data to translate")
 	translateCmd.Flags().BoolVarP(&translateCfg.DoJson, "json", "", false, "initialize as JSON")
 	translateCmd.Flags().BoolVarP(&translateCfg.DoYaml, "yaml", "", false, "initialize as YAML")
 	translateCmd.Flags().BoolVarP(&translateCfg.DoToml, "toml", "", false, "initialize as TOML")

--- a/cmd/translate.go
+++ b/cmd/translate.go
@@ -1,0 +1,52 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+
+	"github.com/spf13/cobra"
+
+	"github.com/Confbase/schema/translate"
+)
+
+var translateCfg translate.Config
+
+// translateCmd represents the translate command
+var translateCmd = &cobra.Command{
+	Use:   "translate",
+	Short: "translate input into desired type",
+	Long: `translate input into desired type
+If no schema is specified, stdin is interpreted as the schema.
+
+Multiple instance names may be specfied.
+
+If more than one of the (json|yaml|toml|xml|protobuf|graphql) flags are set,
+behavior is undefined.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		translate.TranslateEntry(translateCfg, args)
+	},
+}
+
+func init() {
+	translateCmd.Flags().StringVarP(&translateCfg.SchemaPath, "schema", "s", "", "specifies schema to init")
+	translateCmd.Flags().BoolVarP(&translateCfg.DoJson, "json", "", false, "initialize as JSON")
+	translateCmd.Flags().BoolVarP(&translateCfg.DoYaml, "yaml", "", false, "initialize as YAML")
+	translateCmd.Flags().BoolVarP(&translateCfg.DoToml, "toml", "", false, "initialize as TOML")
+	translateCmd.Flags().BoolVarP(&translateCfg.DoXml, "xml", "", false, "initialize as XML")
+	translateCmd.Flags().BoolVarP(&translateCfg.DoProtobuf, "protobuf", "", false, "initialize as protocol buffer")
+	translateCmd.Flags().BoolVarP(&translateCfg.DoGraphQL, "graphql", "", false, "initialize as GraphQL instance")
+	translateCmd.Flags().BoolVarP(&translateCfg.DoPretty, "pretty", "", true, "pretty-print the output")
+	RootCmd.AddCommand(translateCmd)
+}

--- a/e2e_tests/translate.sh
+++ b/e2e_tests/translate.sh
@@ -1,0 +1,517 @@
+#!/bin/bash
+
+translate_unrecognized_format() {
+    output=`printf '{' | schema translate 2>&1`
+    status="$?"
+
+    expect_status='1'
+    expect='error: failed to recognize input data format'
+}
+
+translate_json_to_json_minimal() {
+    output=`printf '{}' | schema translate 2>&1`
+    status="$?"
+
+    expect_status='0'
+    expect='{}'
+}
+
+translate_json_to_json_basic() {
+    output=`printf '{"name":"Bladee","Iceland":42}' | schema translate 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='{
+    "name": "Bladee",
+    "Iceland": 42
+}'
+    expect_or='{
+    "Iceland": 42,
+    "name": "Bladee"
+}'
+}
+
+translate_json_to_json_bool() {
+    output=`printf '{"name":"Bladee","Iceland":true}' | schema translate 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='{
+    "name": "Bladee",
+    "Iceland": true
+}'
+    expect_or='{
+    "Iceland": true,
+    "name": "Bladee"
+}'
+}
+
+translate_json_to_json_array_of_objects() {
+    output=`printf '{"people":[{"name":"Shane MacGowan","ring":"The Snake"}]}' | schema translate 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='{
+    "people": [
+        {
+            "name": "Shane MacGowan",
+            "ring": "The Snake"
+        }
+    ]
+}'
+    expect_or='{
+    "people": [
+        {
+            "ring": "The Snake",
+            "name": "Shane MacGowan"
+        }
+    ]
+}'
+}
+
+translate_json_to_yaml_minimal() {
+    output=`printf '{}' | schema translate --yaml 2>&1`
+    status="$?"
+
+    expect_status='0'
+    expect='{}'
+}
+
+translate_json_to_yaml_basic() {
+    output=`printf '{"name":"Bladee","Iceland":42}' | schema translate --yaml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='name: Bladee
+Iceland: 42'
+    expect_or='Iceland: 42
+name: Bladee'
+}
+
+translate_json_to_yaml_bool() {
+    output=`printf '{"name":"Bladee","Iceland":true}' | schema translate --yaml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='name: Bladee
+Iceland: true'
+    expect_or='Iceland: true
+name: Bladee'
+}
+
+translate_json_to_yaml_array_of_objects() {
+    output=`printf '{"people":[{"name":"Shane MacGowan","ring":"The Snake"}]}' | schema translate --yaml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='people:
+- name: Shane MacGowan
+  ring: The Snake'
+    expect_or='people:
+- ring: The Snake
+  name: Shane MacGowan'
+}
+
+translate_json_to_toml_minimal() {
+    output=`printf '{}' | schema translate --toml 2>&1`
+    status="$?"
+
+    expect_status='0'
+    expect=''
+}
+
+translate_json_to_toml_basic() {
+    output=`printf '{"name":"Bladee","Iceland":42}' | schema translate --toml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='name = "Bladee"
+Iceland = 4.2e+01'
+    expect_or='Iceland = 4.2e+01
+name = "Bladee"'
+}
+
+translate_json_to_toml_bool() {
+    output=`printf '{"name":"Bladee","Iceland":true}' | schema translate --toml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='name = "Bladee"
+Iceland = true'
+    expect_or='Iceland = true
+name = "Bladee"'
+}
+
+translate_json_to_toml_array_of_objects() {
+    output=`printf '{"people":[{"name":"Shane MacGowan","ring":"The Snake"}]}' | schema translate --toml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='[[people]]
+name = "Shane MacGowan"
+ring = "The Snake"'
+    expect_or='[[people]]
+ring = "The Snake"
+name = "Shane MacGowan"'
+}
+
+translate_yaml_to_json_minimal() {
+    output=`printf '{}' | schema translate 2>&1`
+    status="$?"
+
+    expect_status='0'
+    expect='{}'
+}
+
+translate_yaml_to_json_basic() {
+    output=`printf 'name: Bladee\nIceland: 42' | schema translate 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='{
+    "name": "Bladee",
+    "Iceland": 42
+}'
+    expect_or='{
+    "Iceland": 42,
+    "name": "Bladee"
+}'
+}
+
+translate_yaml_to_json_bool() {
+    output=`printf 'name: Bladee\nIceland: true' | schema translate 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='{
+    "name": "Bladee",
+    "Iceland": true
+}'
+    expect_or='{
+    "Iceland": true,
+    "name": "Bladee"
+}'
+}
+
+translate_yaml_to_json_array_of_objects() {
+    output=`printf 'people:\n- name: "Shane MacGowan"\n  ring: "The Snake"' | schema translate 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='{
+    "people": [
+        {
+            "name": "Shane MacGowan",
+            "ring": "The Snake"
+        }
+    ]
+}'
+    expect_or='{
+    "people": [
+        {
+            "ring": "The Snake",
+            "name": "Shane MacGowan"
+        }
+    ]
+}'
+}
+
+translate_yaml_to_yaml_minimal() {
+    output=`printf '{}' | schema translate --yaml 2>&1`
+    status="$?"
+
+    expect_status='0'
+    expect='{}'
+}
+
+translate_yaml_to_yaml_basic() {
+    output=`printf 'name: Bladee\nIceland: 42' | schema translate --yaml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='name: Bladee
+Iceland: 42'
+    expect_or='Iceland: 42
+name: Bladee'
+}
+
+translate_yaml_to_yaml_bool() {
+    output=`printf 'name: Bladee\nIceland: true' | schema translate --yaml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='name: Bladee
+Iceland: true'
+    expect_or='Iceland: true
+name: Bladee'
+}
+
+translate_yaml_to_yaml_array_of_objects() {
+    output=`printf 'people:\n- name: "Shane MacGowan"\n  ring: "The Snake"' | schema translate --yaml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='people:
+- name: Shane MacGowan
+  ring: The Snake'
+    expect_or='people:
+- ring: The Snake
+  name: Shane MacGowan'
+}
+
+translate_yaml_to_toml_minimal() {
+    output=`printf '{}' | schema translate --toml 2>&1`
+    status="$?"
+
+    expect_status='0'
+    expect=''
+}
+
+translate_yaml_to_toml_basic() {
+    output=`printf 'name: Bladee\nIceland: 42' | schema translate --toml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='name = "Bladee"
+Iceland = 42'
+    expect_or='Iceland = 42
+name = "Bladee"'
+}
+
+translate_yaml_to_toml_bool() {
+    output=`printf 'name: Bladee\nIceland: true' | schema translate --toml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='name = "Bladee"
+Iceland = true'
+    expect_or='Iceland = true
+name = "Bladee"'
+}
+
+translate_yaml_to_toml_array_of_objects() {
+    output=`printf 'people:\n- name: "Shane MacGowan"\n  ring: "The Snake"' | schema translate --toml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='[[people]]
+name = "Shane MacGowan"
+ring = "The Snake"'
+    expect_or='[[people]]
+ring = "The Snake"
+name = "Shane MacGowan"'
+}
+
+translate_toml_to_json_minimal() {
+    output=`printf '' | schema translate 2>&1`
+    status="$?"
+
+    expect_status='0'
+    expect='{}'
+}
+
+translate_toml_to_json_basic() {
+    output=`printf 'name = "Bladee"\nIceland = 42' | schema translate 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='{
+    "name": "Bladee",
+    "Iceland": 42
+}'
+    expect_or='{
+    "Iceland": 42,
+    "name": "Bladee"
+}'
+}
+
+translate_toml_to_json_bool() {
+    output=`printf 'name = "Bladee"\nIceland = true' | schema translate 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='{
+    "name": "Bladee",
+    "Iceland": true
+}'
+    expect_or='{
+    "Iceland": true,
+    "name": "Bladee"
+}'
+}
+
+translate_toml_to_json_array_of_objects() {
+    output=`printf '[[people]]\nname = "Shane MacGowan"\nring = "The Snake"' | schema translate 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='{
+    "people": [
+        {
+            "name": "Shane MacGowan",
+            "ring": "The Snake"
+        }
+    ]
+}'
+    expect_or='{
+    "people": [
+        {
+            "ring": "The Snake",
+            "name": "Shane MacGowan"
+        }
+    ]
+}'
+}
+
+translate_toml_to_yaml_minimal() {
+    output=`printf '' | schema translate --yaml 2>&1`
+    status="$?"
+
+    expect_status='0'
+    expect='{}'
+}
+
+translate_toml_to_yaml_basic() {
+    output=`printf 'name = "Bladee"\nIceland = 42' | schema translate --yaml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='name: Bladee
+Iceland: 42'
+    expect_or='Iceland: 42
+name: Bladee'
+}
+
+translate_toml_to_yaml_bool() {
+    output=`printf 'name = "Bladee"\nIceland = true' | schema translate --yaml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='name: Bladee
+Iceland: true'
+    expect_or='Iceland: true
+name: Bladee'
+}
+
+translate_toml_to_yaml_array_of_objects() {
+    output=`printf '[[people]]\nname = "Shane MacGowan"\nring = "The Snake"' | schema translate --yaml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='people:
+- name: Shane MacGowan
+  ring: The Snake'
+    expect_or='people:
+- ring: The Snake
+  name: Shane MacGowan'
+}
+
+translate_toml_to_toml_minimal() {
+    output=`printf '' | schema translate --toml 2>&1`
+    status="$?"
+
+    expect_status='0'
+    expect=''
+}
+
+translate_toml_to_toml_basic() {
+    output=`printf 'name = "Bladee"\nIceland = 42' | schema translate --toml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='name = "Bladee"
+Iceland = 42'
+    expect_or='Iceland = 42
+name = "Bladee"'
+}
+
+translate_toml_to_toml_bool() {
+    output=`printf 'name = "Bladee"\nIceland = true' | schema translate --toml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='name = "Bladee"
+Iceland = true'
+    expect_or='Iceland = true
+name = "Bladee"'
+}
+
+translate_toml_to_toml_array_of_objects() {
+    output=`printf '[[people]]\nname = "Shane MacGowan"\nring = "The Snake"' | schema translate --toml 2>&1`
+    status="$?"
+
+    expect_either_or='true'
+    expect_status='0'
+    expect_either='[[people]]
+name = "Shane MacGowan"
+ring = "The Snake"'
+    expect_or='[[people]]
+ring = "The Snake"
+name = "Shane MacGowan"'
+}
+
+tests=(
+    "translate_unrecognized_format"
+    "translate_json_to_json_minimal"
+    "translate_json_to_json_basic"
+    "translate_json_to_json_bool"
+    "translate_json_to_json_array_of_objects"
+    "translate_json_to_yaml_minimal"
+    "translate_json_to_yaml_basic"
+    "translate_json_to_yaml_bool"
+    "translate_json_to_yaml_array_of_objects"
+    "translate_json_to_toml_minimal"
+    "translate_json_to_toml_basic"
+    "translate_json_to_toml_bool"
+    "translate_json_to_toml_array_of_objects"
+    "translate_yaml_to_json_minimal"
+    "translate_yaml_to_json_basic"
+    "translate_yaml_to_json_bool"
+    "translate_yaml_to_json_array_of_objects"
+    "translate_yaml_to_yaml_minimal"
+    "translate_yaml_to_yaml_basic"
+    "translate_yaml_to_yaml_bool"
+    "translate_yaml_to_yaml_array_of_objects"
+    "translate_yaml_to_toml_minimal"
+    "translate_yaml_to_toml_basic"
+    "translate_yaml_to_toml_bool"
+    "translate_yaml_to_toml_array_of_objects"
+    "translate_toml_to_json_minimal"
+    "translate_toml_to_json_basic"
+    "translate_toml_to_json_bool"
+    "translate_toml_to_json_array_of_objects"
+    "translate_toml_to_yaml_minimal"
+    "translate_toml_to_yaml_basic"
+    "translate_toml_to_yaml_bool"
+    "translate_toml_to_yaml_array_of_objects"
+    "translate_toml_to_toml_minimal"
+    "translate_toml_to_toml_basic"
+    "translate_toml_to_toml_bool"
+    "translate_toml_to_toml_array_of_objects"
+)

--- a/infer/infer.go
+++ b/infer/infer.go
@@ -1,19 +1,13 @@
 package infer
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
-
-	"github.com/clbanning/mxj"
-	"github.com/naoina/toml"
-	"gopkg.in/yaml.v2"
 
 	"github.com/Confbase/schema/example"
 	"github.com/Confbase/schema/jsonsch"
+	"github.com/Confbase/schema/util"
 )
 
 func InferEntry(cfg Config, args []string) {
@@ -29,7 +23,7 @@ func InferEntry(cfg Config, args []string) {
 }
 
 func Infer(r io.Reader, w io.Writer, cfg Config) error {
-	data, err := readToMap(r)
+	data, err := util.MuxDecode(r)
 	if err != nil {
 		return err
 	}
@@ -45,37 +39,4 @@ func Infer(r io.Reader, w io.Writer, cfg Config) error {
 	}
 
 	return nil
-}
-
-func readToMap(r io.Reader) (map[string]interface{}, error) {
-	// ReadAll is necessary, since the input stream could be only
-	// traversable once; we must be sure to save the data
-	// into a buffer on the first pass, so that we can read it
-	// *multiple* times
-	buf, err := ioutil.ReadAll(r)
-	if err != nil {
-		return nil, err
-	}
-
-	data := make(map[string]interface{})
-	if err = json.Unmarshal(buf, &data); err == nil {
-		return data, nil
-	}
-
-	data = make(map[string]interface{}) // be sure it's an empty map
-	if err = yaml.Unmarshal(buf, &data); err == nil {
-		return data, nil
-	}
-
-	data = make(map[string]interface{}) // be sure it's an empty map
-	if err = toml.Unmarshal(buf, &data); err == nil {
-		return data, nil
-	}
-
-	mv, err := mxj.NewMapXmlReader(bytes.NewReader(buf))
-	if err == nil {
-		return map[string]interface{}(mv), nil
-	}
-
-	return nil, fmt.Errorf("failed to recognize input data format")
 }

--- a/initcmd/initcmd.go
+++ b/initcmd/initcmd.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/Confbase/schema/jsonsch"
+	"github.com/Confbase/schema/util"
 )
 
 func Init(cfg Config, targets []string) {
@@ -36,12 +37,12 @@ func Init(cfg Config, targets []string) {
 	}
 
 	if len(targets) == 0 {
-		instance, err := jsonsch.InitSchema(js)
+		inst, err := jsonsch.InitSchema(js)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: failed to initialize instance of schema\n%v\n", err)
 			os.Exit(1)
 		}
-		if err := jsonsch.SerializeInstance(instance, os.Stdout, cfg.OutFmt(), cfg.DoPretty); err != nil {
+		if err := util.DemuxEncode(os.Stdout, inst, util.OutFmt(cfg.OutFmt()), cfg.DoPretty); err != nil {
 			fmt.Fprintf(os.Stderr, "error: failed to serialize instance of schema\n%v\n", err)
 			os.Exit(1)
 		}
@@ -56,12 +57,12 @@ func Init(cfg Config, targets []string) {
 		}
 		defer f.Close()
 
-		instance, err := jsonsch.InitSchema(js)
+		inst, err := jsonsch.InitSchema(js)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: failed to initialize instance of schema\n%v\n", err)
 			os.Exit(1)
 		}
-		if err := jsonsch.SerializeInstance(instance, f, cfg.OutFmt(), cfg.DoPretty); err != nil {
+		if err := util.DemuxEncode(os.Stdout, inst, util.OutFmt(cfg.OutFmt()), cfg.DoPretty); err != nil {
 			fmt.Fprintf(os.Stderr, "error: failed to serialize instance of schema\n%v\n", err)
 			os.Exit(1)
 		}

--- a/jsonsch/serialize.go
+++ b/jsonsch/serialize.go
@@ -2,11 +2,7 @@ package jsonsch
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
-
-	"github.com/naoina/toml"
-	"gopkg.in/yaml.v2"
 )
 
 func SerializeSchema(s Schema, w io.Writer, doPretty bool) error {
@@ -20,6 +16,7 @@ func SerializeSchema(s Schema, w io.Writer, doPretty bool) error {
 	return nil
 }
 
+/*
 func SerializeInstance(inst map[string]interface{}, w io.Writer, outFmt string, doPretty bool) error {
 	switch outFmt {
 	case "json":
@@ -45,3 +42,4 @@ func SerializeInstance(inst map[string]interface{}, w io.Writer, outFmt string, 
 	}
 	return nil
 }
+*/

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 printf "Running gofmt tests..."
-gofmt_output="$(git ls-files | grep -v "$(git ls-files -d)" | grep '.go$' | xargs gofmt -l)"
+gofmt_output="$(git ls-files | grep -v "^$(git ls-files -d)\$" | grep '.go$' | xargs gofmt -l)"
 if [ ! -z "$gofmt_output" ]; then
     printf "FAIL. The following files are not gofmt'd:\n$gofmt_output" 1>&2
     exit 1

--- a/translate/config.go
+++ b/translate/config.go
@@ -1,7 +1,7 @@
 package translate
 
 type Config struct {
-	SchemaPath string
+	InputPath  string
 	DoJson     bool
 	DoYaml     bool
 	DoToml     bool

--- a/translate/config.go
+++ b/translate/config.go
@@ -1,0 +1,34 @@
+package translate
+
+type Config struct {
+	SchemaPath string
+	DoJson     bool
+	DoYaml     bool
+	DoToml     bool
+	DoXml      bool
+	DoProtobuf bool
+	DoGraphQL  bool
+	DoPretty   bool
+}
+
+func (translate *Config) OutFmt() string {
+	if translate.DoJson {
+		return "json"
+	}
+	if translate.DoYaml {
+		return "yaml"
+	}
+	if translate.DoToml {
+		return "toml"
+	}
+	if translate.DoXml {
+		return "xml"
+	}
+	if translate.DoProtobuf {
+		return "protobuf"
+	}
+	if translate.DoGraphQL {
+		return "graphql"
+	}
+	return "json"
+}

--- a/translate/translate.go
+++ b/translate/translate.go
@@ -1,0 +1,89 @@
+package translate
+
+import(
+	"os"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"github.com/clbanning/mxj"
+    "github.com/naoina/toml"
+	"gopkg.in/yaml.v2"
+	"bytes"
+	"fmt"
+)
+
+func TranslateEntry(cfg Config, args []string) {
+	if len(args) == 0 {
+		if err := Translate(os.Stdin, os.Stdout, cfg); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "error: not implemented yet\n")
+		os.Exit(1)
+	}
+}
+
+func Translate(r io.Reader, w io.Writer, cfg Config) error{
+	m, err := readToMap(r)
+	if (err != nil){
+		return err;
+		}
+		outFmt := cfg.OutFmt()
+		switch cfg.OutFmt() {
+		case "json":
+			enc := json.NewEncoder(w)
+			if cfg.DoPretty {
+				enc.SetIndent("", "    ")
+			}
+			if err := enc.Encode(&m); err != nil {
+				return err
+			}
+		case "yaml":
+			if err := yaml.NewEncoder(w).Encode(&m); err != nil {
+				return err
+			}
+		case "toml":
+			if err := toml.NewEncoder(w).Encode(&m); err != nil {
+				return err
+			}
+		case "xml", "protobuf", "graphql":
+			return fmt.Errorf("'%v' is not implemented yet", outFmt)
+		default:
+			return fmt.Errorf("unrecognized output format '%v'", outFmt)
+		}
+		return nil
+}
+
+func readToMap(r io.Reader) (map[string]interface{}, error) {
+	// ReadAll is necessary, since the input stream could be only
+	// traversable once; we must be sure to save the data
+	// into a buffer on the first pass, so that we can read it
+	// *multiple* times
+	buf, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	data := make(map[string]interface{})
+	if err = json.Unmarshal(buf, &data); err == nil {
+		return data, nil
+	}
+
+	data = make(map[string]interface{}) // be sure it's an empty map
+	if err = yaml.Unmarshal(buf, &data); err == nil {
+		return data, nil
+	}
+
+	data = make(map[string]interface{}) // be sure it's an empty map
+	if err = toml.Unmarshal(buf, &data); err == nil {
+		return data, nil
+	}
+
+	mv, err := mxj.NewMapXmlReader(bytes.NewReader(buf))
+	if err == nil {
+		return map[string]interface{}(mv), nil
+	}
+
+	return nil, fmt.Errorf("failed to recognize input data format")
+}

--- a/util/serialize.go
+++ b/util/serialize.go
@@ -1,0 +1,74 @@
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/clbanning/mxj"
+	"github.com/naoina/toml"
+	"gopkg.in/yaml.v2"
+)
+
+func MuxDecode(r io.Reader) (map[string]interface{}, error) {
+	// ReadAll is necessary, since the input stream could be only
+	// traversable once; we must be sure to save the data
+	// into a buffer on the first pass, so that we can read it
+	// *multiple* times
+	buf, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	data := make(map[string]interface{})
+	if err = json.Unmarshal(buf, &data); err == nil {
+		return data, nil
+	}
+
+	data = make(map[string]interface{}) // be sure it's an empty map
+	if err = yaml.Unmarshal(buf, &data); err == nil {
+		return data, nil
+	}
+
+	data = make(map[string]interface{}) // be sure it's an empty map
+	if err = toml.Unmarshal(buf, &data); err == nil {
+		return data, nil
+	}
+
+	mv, err := mxj.NewMapXmlReader(bytes.NewReader(buf))
+	if err == nil {
+		return map[string]interface{}(mv), nil
+	}
+
+	return nil, fmt.Errorf("failed to recognize input data format")
+}
+
+type OutFmt string
+
+func DemuxEncode(w io.Writer, data interface{}, outFmt OutFmt, doPretty bool) error {
+	switch string(outFmt) {
+	case "json":
+		enc := json.NewEncoder(w)
+		if doPretty {
+			enc.SetIndent("", "    ")
+		}
+		if err := enc.Encode(&data); err != nil {
+			return err
+		}
+	case "yaml":
+		if err := yaml.NewEncoder(w).Encode(&data); err != nil {
+			return err
+		}
+	case "toml":
+		if err := toml.NewEncoder(w).Encode(&data); err != nil {
+			return err
+		}
+	case "xml", "protobuf", "graphql":
+		return fmt.Errorf("'%v' is not implemented yet", outFmt)
+	default:
+		return fmt.Errorf("unrecognized output format '%v'", outFmt)
+	}
+	return nil
+}


### PR DESCRIPTION
This replaces #31 

Changes:

* Found an edge case where YAML and TOML would return map[interface{]]interface{] instead of map[string]interface{} objects. This broke the translate command when translating an array of objects from YAML or TOML. This involved serious engineering and refactoring to fix the problem.
* Add lots of e2e tests.
* Refactor and de-duplicate code.

Closes #26 