### PR TITLE
Rudimentary version command

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -24,8 +24,8 @@ const version = "v0.0.1"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Outputs the version of scheme",
-	Long:  `Outputs the current version of scheme installed.`,
+	Short: "Outputs the version of schema",
+	Long:  `Outputs the current version of schema installed.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(version)
 	},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -25,7 +25,7 @@ const version = "v0.0.1"
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Outputs the version of scheme",
-	Long: `Outputs the current version of scheme installed.`,
+	Long:  `Outputs the current version of scheme installed.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(version)
 	},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -24,8 +24,8 @@ const version = "v0.0.1"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Outputs the version of schema",
-	Long:  `Outputs the current version of schema installed.`,
+	Short: "Prints the version of schema",
+	Long:  `Prints the current version of schema installed.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(version)
 	},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,36 @@
+// Copyright © 2018 Confbase
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const version = "v0.0.1"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Outputs the version of scheme",
+	Long: `Outputs the current version of scheme installed.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
Simple version command using a constant, will be replaced by goreleases in the future.